### PR TITLE
overriding input default classes with custom tailwind classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,9 @@
     "typedoc": "^0.26.6",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.2.0"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "tw-merge": "^0.0.1-alpha.3"
   }
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -36,6 +36,7 @@ import clsx from "clsx";
  * @property {string | React.ReactElement} [startIcon] - icon or text to display at the start of the Input component
  * @property {string | React.ReactElement} [endIcon] - icon or text to display at the end of the Input component
  * @property {"on" | "off"} [autoComplete] - whether the Input component should have autocomplete enabled
+ * @property {string} [className] - User defined tailwind classes to override default mui classes
  */
 
 /**
@@ -92,7 +93,10 @@ export type InputProps = {
    * @param {{autoComplete: "on" | "off"}}
    */
   autoComplete?: "on" | "off";
-  className: string;
+  /**
+   * @param {string} [className] - User-defined Tailwind classes to override default Material-UI classes.
+   */
+  className?: string;
 };
 
 function Input({

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,6 +4,8 @@ import TextField from "@mui/material/TextField";
 import { IconButton, InputAdornment } from "@mui/material";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
+import { twMerge } from "tw-merge";
+import clsx from "clsx";
 
 /**
  * @typedef {Object} MultilineConfig
@@ -90,6 +92,7 @@ export type InputProps = {
    * @param {{autoComplete: "on" | "off"}}
    */
   autoComplete?: "on" | "off";
+  className:string
 };
 
 function Input({
@@ -112,6 +115,7 @@ function Input({
   startIcon,
   endIcon,
   autoComplete,
+  className
 }: InputProps) {
   const {
     control,
@@ -123,6 +127,21 @@ function Input({
   const handleShowPasswordClick = () => setShowPassword(!showPassword);
   const handleMouseDownPassword = (e: React.MouseEvent<HTMLButtonElement>) =>
     e.preventDefault();
+
+  const muiDefaultClasses = twMerge(
+    clsx(
+      // MUI classes first
+      "MuiTextField-root",
+      variant === "outlined" ? "MuiOutlinedInput-root" : "",
+      variant === "filled" ? "MuiFilledInput-root" : "",
+      variant === "standard" ? "MuiInput-root" : "",
+      disabled ? "Mui-disabled" : "",
+      errors[name] ? "Mui-error" : "",
+      // Tailwind classes last
+      className // Tailwind classes should be at the end
+    )
+  );
+  
   return (
     <Controller
       control={control}
@@ -190,6 +209,7 @@ function Input({
               ),
             }),
           }}
+          className={muiDefaultClasses}
         />
       )}
     />

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -92,7 +92,7 @@ export type InputProps = {
    * @param {{autoComplete: "on" | "off"}}
    */
   autoComplete?: "on" | "off";
-  className:string
+  className: string;
 };
 
 function Input({
@@ -115,7 +115,7 @@ function Input({
   startIcon,
   endIcon,
   autoComplete,
-  className
+  className,
 }: InputProps) {
   const {
     control,
@@ -141,7 +141,7 @@ function Input({
       className // Tailwind classes should be at the end
     )
   );
-  
+
   return (
     <Controller
       control={control}

--- a/test/src/App.jsx
+++ b/test/src/App.jsx
@@ -25,7 +25,7 @@ function App() {
             required
             type="text"
             fullWidth
-            className={"bg-black font-mono font-bold"}
+            className={"bg-black text-green-300"}
           />
           <Input
             name="lName"

--- a/test/src/App.jsx
+++ b/test/src/App.jsx
@@ -25,6 +25,7 @@ function App() {
             required
             type="text"
             fullWidth
+            className={"bg-black font-mono font-bold"}
           />
           <Input
             name="lName"

--- a/test/tailwind.config.js
+++ b/test/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  important:"#root",
+  important: "#root",
   theme: {
     extend: {},
   },

--- a/test/tailwind.config.js
+++ b/test/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  important:"#root",
   theme: {
     extend: {},
   },


### PR DESCRIPTION
---
name: Pull request
about: Maintain this format while making a PR
title: ""
labels: ""
assignees: "shivansh"
---

## Description
I have modified the code to override the className provided by the user over default css. 
The user just has to make 1 change in the tailwind.config.js of their project by adding [important: "#root"] in the default export and they are good to go....now they can add tailwind classes and the changes will reflect.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Chore (cleanup or minor improvement that does not change functionality)

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/da70ffb8-10c6-4dca-93ad-85764563fade)
![image](https://github.com/user-attachments/assets/9e7730fd-0489-4079-9045-fa9297ff06ab)
![image](https://github.com/user-attachments/assets/50fe6709-ea25-41e3-954a-d79773066e6f)


If applicable, please add screenshots to illustrate the changes.

## Additional Information

Please add any other relevant information or context for the reviewers.
